### PR TITLE
feat: implement nprogress on route change

### DIFF
--- a/lib/useFetch.ts
+++ b/lib/useFetch.ts
@@ -1,0 +1,16 @@
+import useSWR, { Fetcher } from "swr"
+
+const useFetch = <T>(url: string) => {
+  const fetcher: Fetcher<T> = (input: RequestInfo, init?: RequestInit) =>
+    fetch(input, init).then((res) => res.json())
+
+  const { data, error } = useSWR<T, Error>(url, fetcher)
+
+  return {
+    data,
+    error,
+    isLoading: !error && !data,
+  }
+}
+
+export default useFetch

--- a/package.json
+++ b/package.json
@@ -27,8 +27,10 @@
   },
   "dependencies": {
     "next": "12.1.5",
+    "nprogress": "^0.2.0",
     "react": "18.0.0",
-    "react-dom": "18.0.0"
+    "react-dom": "18.0.0",
+    "swr": "^1.3.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^16.2.3",
@@ -38,6 +40,7 @@
     "@testing-library/react": "^13.1.1",
     "@types/jest": "^27.4.1",
     "@types/node": "17.0.25",
+    "@types/nprogress": "^0.2.0",
     "@types/react": "18.0.5",
     "@types/react-dom": "18.0.1",
     "@types/testing-library__jest-dom": "^5.14.3",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,8 +1,34 @@
-import "@/styles/globals.css"
+import { useEffect } from "react"
+import { useRouter } from "next/router"
 import type { AppProps } from "next/app"
 import Head from "next/head"
+import NProgress from "nprogress"
+
+import "@/styles/nprogress.css"
+import "@/styles/globals.css"
 
 function MyApp({ Component, pageProps }: AppProps) {
+  const router = useRouter()
+
+  NProgress.configure({
+    showSpinner: false,
+  })
+
+  useEffect(() => {
+    const handleRouteStart = () => NProgress.start()
+    const handleRouteDone = () => NProgress.done()
+
+    router.events.on("routeChangeStart", handleRouteStart)
+    router.events.on("routeChangeComplete", handleRouteDone)
+    router.events.on("routeChangeError", handleRouteDone)
+
+    return () => {
+      router.events.off("routeChangeStart", handleRouteStart)
+      router.events.off("routeChangeComplete", handleRouteDone)
+      router.events.off("routeChangeError", handleRouteDone)
+    }
+  }, [router])
+
   return (
     <div>
       <Head>

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -1,9 +1,23 @@
 import type { NextPage } from "next"
+import Link from "next/link"
+import useFetch from "@/lib/useFetch"
+
+type ApiResponse = {
+  name: string
+}
 
 const About: NextPage = () => {
+  const { data, error, isLoading } = useFetch<ApiResponse>("/api/hello")
+
+  if (error) return <div>Failed to load</div>
+  if (isLoading) return <div>Loading...</div>
+
   return (
     <div>
       <h1>About Page</h1>
+      <span>{data?.name}</span>
+      <br />
+      <Link href="/">Go home</Link>
       <p>
         Lorem ipsum dolor sit amet consectetur adipisicing elit. Iure quas
         nesciunt quaerat cupiditate illo vero a nostrum minima molestias,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,7 @@ specifiers:
   "@testing-library/react": ^13.1.1
   "@types/jest": ^27.4.1
   "@types/node": 17.0.25
+  "@types/nprogress": ^0.2.0
   "@types/react": 18.0.5
   "@types/react-dom": 18.0.1
   "@types/testing-library__jest-dom": ^5.14.3
@@ -24,15 +25,19 @@ specifiers:
   jest: ^27.5.1
   lint-staged: ^12.4.0
   next: 12.1.5
+  nprogress: ^0.2.0
   prettier: ^2.6.2
   react: 18.0.0
   react-dom: 18.0.0
+  swr: ^1.3.0
   typescript: 4.6.3
 
 dependencies:
   next: 12.1.5_zpnidt7m3osuk7shl3s4oenomq
+  nprogress: 0.2.0
   react: 18.0.0
   react-dom: 18.0.0_react@18.0.0
+  swr: 1.3.0_react@18.0.0
 
 devDependencies:
   "@commitlint/cli": 16.2.3
@@ -42,6 +47,7 @@ devDependencies:
   "@testing-library/react": 13.1.1_zpnidt7m3osuk7shl3s4oenomq
   "@types/jest": 27.4.1
   "@types/node": 17.0.25
+  "@types/nprogress": 0.2.0
   "@types/react": 18.0.5
   "@types/react-dom": 18.0.1
   "@types/testing-library__jest-dom": 5.14.3
@@ -1790,6 +1796,13 @@ packages:
     resolution:
       {
         integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==,
+      }
+    dev: true
+
+  /@types/nprogress/0.2.0:
+    resolution:
+      {
+        integrity: sha512-1cYJrqq9GezNFPsWTZpFut/d4CjpZqA0vhqDUPFWYKF1oIyBz5qnoYMzR+0C/T96t3ebLAC1SSnwrVOm5/j74A==,
       }
     dev: true
 
@@ -5969,6 +5982,10 @@ packages:
       path-key: 3.1.1
     dev: true
 
+  /nprogress/0.2.0:
+    resolution: { integrity: sha1-y480xTIT2JVyP8urkH6UIq28r7E= }
+    dev: false
+
   /nwsapi/2.2.0:
     resolution:
       {
@@ -7301,6 +7318,17 @@ packages:
       }
     engines: { node: ">= 0.4" }
     dev: true
+
+  /swr/1.3.0_react@18.0.0:
+    resolution:
+      {
+        integrity: sha512-dkghQrOl2ORX9HYrMDtPa7LTVHJjCTeZoB1dqTbnnEDlSvN8JEKpYIYurDfvbQFUUS8Cg8PceFVZNkW0KNNYPw==,
+      }
+    peerDependencies:
+      react: ^16.11.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      react: 18.0.0
+    dev: false
 
   /symbol-tree/3.2.4:
     resolution:

--- a/styles/nprogress.css
+++ b/styles/nprogress.css
@@ -1,0 +1,83 @@
+/* Make clicks pass-through */
+#nprogress {
+  --nprogress-color: red;
+
+  pointer-events: none;
+}
+
+#nprogress .bar {
+  background: var(--nprogress-color);
+
+  position: fixed;
+  z-index: 1031;
+  top: 0;
+  left: 0;
+
+  width: 100%;
+  height: 2px;
+}
+
+/* Fancy blur effect */
+#nprogress .peg {
+  display: block;
+  position: absolute;
+  right: 0px;
+  width: 100px;
+  height: 100%;
+  box-shadow: 0 0 10px var(--nprogress-color), 0 0 5px var(--nprogress-color);
+  opacity: 1;
+
+  -webkit-transform: rotate(3deg) translate(0px, -4px);
+  -ms-transform: rotate(3deg) translate(0px, -4px);
+  transform: rotate(3deg) translate(0px, -4px);
+}
+
+/* Remove these to get rid of the spinner */
+#nprogress .spinner {
+  display: block;
+  position: fixed;
+  z-index: 1031;
+  top: 15px;
+  right: 15px;
+}
+
+#nprogress .spinner-icon {
+  width: 18px;
+  height: 18px;
+  box-sizing: border-box;
+
+  border: solid 2px transparent;
+  border-top-color: var(--nprogress-color);
+  border-left-color: var(--nprogress-color);
+  border-radius: 50%;
+
+  -webkit-animation: nprogress-spinner 400ms linear infinite;
+  animation: nprogress-spinner 400ms linear infinite;
+}
+
+.nprogress-custom-parent {
+  overflow: hidden;
+  position: relative;
+}
+
+.nprogress-custom-parent #nprogress .spinner,
+.nprogress-custom-parent #nprogress .bar {
+  position: absolute;
+}
+
+@-webkit-keyframes nprogress-spinner {
+  0% {
+    -webkit-transform: rotate(0deg);
+  }
+  100% {
+    -webkit-transform: rotate(360deg);
+  }
+}
+@keyframes nprogress-spinner {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}

--- a/tests/about.test.tsx
+++ b/tests/about.test.tsx
@@ -1,6 +1,14 @@
 import { render, screen } from "@testing-library/react"
 import About from "@/pages/about"
 
+jest.mock("@/lib/useFetch", () => {
+  return () => ({
+    data: {
+      name: "John Doe",
+    },
+  })
+})
+
 describe("About", () => {
   it("renders a heading", () => {
     render(<About />)


### PR DESCRIPTION
Shows a progress bar when changing routes, but not on initial load.
Does not account for content loaded after route change (like data fetched from API)
Also implements a useFetch hook built on useSWR, and a mock for it in about.test.tsx
